### PR TITLE
docs: add interactive embedded systems skill tree link

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Additionally, the [Arduino Core](https://github.com/arduino/ArduinoCore-API) tak
 
 - [🔗 Embedded Artistry Beginners Roadmap](https://embeddedartistry.com/beginners/)
 - [🔗 Embedded Systems Skill Tree](https://github.com/sjpiper145/MakerSkillTree/tree/main/Embedded%20Systems%20Skill%20Tree)
+- [🔗 Interactive Embedded Systems Skill Tree (with progress tracking & sync)](https://colonelblacc.github.io/Embedded-Systems-SkillTree)
 - [🔗 PCB Design Skill Tree](https://github.com/sjpiper145/MakerSkillTree/tree/main/PCB%20Design%20Skill%20Tree)
 - [🔗 FPGA / ASIC Engineering Roadmap](https://github.com/m3y54m/FPGA-ASIC-Roadmap)
 


### PR DESCRIPTION
## Description

Adds a link to an interactive, browser-based version of the Embedded Systems Skill Tree under **Other Helpful Roadmaps**.

**Live demo:** https://colonelblacc.github.io/Embedded-Systems-SkillTree
**Source:** https://github.com/colonelblacc/Embedded-Systems-SkillTree

### What it adds
- Interactive SVG hex-grid where users click to mark skills as complete
- Real-time progress sync via Firebase, with LocalStorage fallback (no setup needed)
- Shareable profile links via ?user=USERNAME
- Built on top of the [MakerSkillTree](https://github.com/sjpiper145/MakerSkillTree) template (already listed above)
- Free and open source (CC BY-NC-SA 4.0)

### Change
One line added under Other Helpful Roadmaps in README.md.